### PR TITLE
Plugin should work for Firefox .webidl files

### DIFF
--- a/IDL.tmLanguage
+++ b/IDL.tmLanguage
@@ -5,6 +5,7 @@
 	<key>fileTypes</key>
 	<array>
 		<string>idl</string>
+		<string>webidl</string>
 	</array>
 	<key>firstLineMatch</key>
 	<string>-[*]-( Mode:)? C -[*]-</string>


### PR DESCRIPTION
Mozilla Firefox source code uses .webidl for IDL files.

Examples: https://mxr.mozilla.org/mozilla-central/source/dom/webidl/
