### PR TITLE
Scope names conflict

### DIFF
--- a/IDL.tmLanguage
+++ b/IDL.tmLanguage
@@ -1302,7 +1302,7 @@
 		</dict>
 	</dict>
 	<key>scopeName</key>
-	<string>source.idl</string>
+	<string>source.webidl</string>
 	<key>uuid</key>
 	<string>25066DC2-6B1D-11D9-9D5B-000D93589AF6</string>
 </dict>


### PR DESCRIPTION
We would like to use this Sublime Text package at github/linguist#1850 to highlight WebIDL code on GitHub.
However, the scope name `source.idl` is already used by [IDL](https://github.com/github/linguist/tree/master/samples/IDL).

This pull request changes it to `source.webidl`. Would that be possible?
