### PR TITLE
Explicit count modifiers

### DIFF
--- a/IDL.tmLanguage
+++ b/IDL.tmLanguage
@@ -1262,7 +1262,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\\(\\|[abefnprtv'"?]|[0-3]\d{,2}|[4-7]\d?|x[a-fA-F0-9]{,2}|u[a-fA-F0-9]{,4}|U[a-fA-F0-9]{,8})</string>
+					<string>\\(\\|[abefnprtv'"?]|[0-3]\d{0,2}|[4-7]\d?|x[a-fA-F0-9]{0,2}|u[a-fA-F0-9]{0,4}|U[a-fA-F0-9]{0,8})</string>
 					<key>name</key>
 					<string>constant.character.escape.webidl</string>
 				</dict>


### PR DESCRIPTION
The construction `{,2}` in regular expressions is only supported by Oniguruma (which is used by Sublime Text). This package is used to highlight IDL code on GitHub. However, GitHub is using a [PCRE-based engine](https://github.com/vmg/pcre) for regexes and thus, the following code gets incorrectly highlighted.
```webidl
DOMString animationName = "\00";
```

This pull request fixes that by using an explicit count modifier in the regex.