### PR TITLE
Windows types and constants

### DIFF
--- a/IDL.tmLanguage
+++ b/IDL.tmLanguage
@@ -432,6 +432,18 @@
 			<string>support.type.mac-classic.webidl</string>
 		</dict>
 		<dict>
+			<key>match</key>
+			<string>\b(DISPID_NEWENUM|DISPID_VALUE)\b</string>
+			<key>name</key>
+			<string>constant.language.windows.webidl</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\b(BOOL|BYTE|CLSID|COLORREF|DECIMAL|DOUBLE|DWORD|FLOAT|GUID|HDC|HRESULT|HWND|IDispatch|INT|IUnknown|IWeakReference|LONG|LPSTR|LPWSTR|MSG|OLE_COLOR|RECT|REFIID|SHORT|TCHAR|UINT|UINT_PTR|ULONG|ULONGLONG|VARIANT_BOOL)\b</string>
+			<key>name</key>
+			<string>storage.type.windows.webidl</string>
+		</dict>
+		<dict>
 			<key>include</key>
 			<string>#block</string>
 		</dict>


### PR DESCRIPTION
To improve the Windows midl support I added some common types and also two constants which are often used for method IDs.